### PR TITLE
Rename & Syntax Fix

### DIFF
--- a/Linear_regression.ipynb
+++ b/Linear_regression.ipynb
@@ -38,7 +38,7 @@
         }
       ],
       "source": [
-        "pip install scikit-learn"
+        "!pip install scikit-learn"
       ]
     },
     {


### PR DESCRIPTION
1. Changed file name from LInear-Regression to Linear-Regression
2. Added '!' before 'pip'